### PR TITLE
Update build namelist checks for valid landuse v2 mode combinations

### DIFF
--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -4389,7 +4389,6 @@ sub setup_logic_fates {
                             "Change suplnitro back to ALL");
         }
 
-        #
         # For FATES SP mode make sure no-competetiion, and fixed-biogeography are also set
         # And also check for other settings that can't be trigged on as well
         #
@@ -4434,12 +4433,13 @@ sub setup_logic_fates {
             } elsif ( ! -f "$fname" ) {
               $log->fatal_error("$fname does NOT point to a valid filename" );
             }
-          }
-          # make sure that nocomp and fbg mode are enabled as well as use_fates_luh
-          my @list = ( "use_fates_nocomp", "use_fates_fixed_biogeog, use_fates_luh" );
-          foreach my $var ( @list ) {
-            if ( ! &value_is_true($nl->get_value($var)) ) {
-              $log->fatal_error("$var is required when use_fates_lupft is true" );
+
+            # make sure that nocomp and fbg mode are enabled as well as use_fates_luh
+            my @list = ( "use_fates_nocomp", "use_fates_fixed_biogeog, use_fates_luh" );
+            foreach my $var ( @list ) {
+              if ( ! &value_is_true($nl->get_value($var)) ) {
+                $log->fatal_error("$var is required when use_fates_lupft is true" );
+              }
             }
           }
         }
@@ -4456,9 +4456,6 @@ sub setup_logic_fates {
               } elsif ( ! -f "$fname" ) {
                  $log->fatal_error("$fname does NOT point to a valid filename" );
               }
-
-              $var = "flandusepftdat";
-              add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, $var, 'phys'=>$nl_flags->{'phys'}, 'hgrid'=>$nl_flags->{'res'}, 'sim_year_range'=>$nl_flags->{'sim_year_range'}, nofail=>1 );
            }
         }
         # check that fates landuse is on and harvest mode is off when potential veg switch is true

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -4371,12 +4371,16 @@ sub setup_logic_fates {
         add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'fates_paramfile', 'phys'=>$nl_flags->{'phys'});
         my @list  = (  "fates_spitfire_mode", "use_fates_planthydro", "use_fates_ed_st3", "use_fates_ed_prescribed_phys",
                        "use_fates_inventory_init","use_fates_fixed_biogeog","use_fates_nocomp","fates_seeddisp_cadence",
-                       "fates_harvest_mode","fates_parteh_mode", "use_fates_cohort_age_tracking","use_fates_tree_damage",
-                       "use_fates_luh","use_fates_lupft" );
+                       "fates_harvest_mode","fates_parteh_mode", "use_fates_cohort_age_tracking","use_fates_tree_damage");
         foreach my $var ( @list ) {
  	  add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, $var, 'use_fates'=>$nl_flags->{'use_fates'},
                       'use_fates_sp'=>$nl_flags->{'use_fates_sp'} );
         }
+
+ 	add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_lupft', 'use_fates'=>$nl_flags->{'use_fates'});
+ 	add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_luh', 'use_fates'=>$nl_flags->{'use_fates'},
+                      'use_fates_lupft'=>$nl_flags->{'use_fates_lupft'} );
+
         my $suplnitro = $nl->get_value('suplnitro');
         my $parteh_mode = $nl->get_value('fates_parteh_mode');
         if ( ($parteh_mode == 1) &&  ($suplnitro !~ /ALL/) && not &value_is_true( $nl_flags->{'use_fates_sp'}) ) {
@@ -4384,6 +4388,7 @@ sub setup_logic_fates {
                             "but and FATES-SP is not active, but fates_parteh_mode is 1, so Nitrogen is not active" . 
                             "Change suplnitro back to ALL");
         }
+
         #
         # For FATES SP mode make sure no-competetiion, and fixed-biogeography are also set
         # And also check for other settings that can't be trigged on as well
@@ -4425,16 +4430,16 @@ sub setup_logic_fates {
                         'phys'=>$nl_flags->{'phys'}, 'hgrid'=>$nl_flags->{'res'}, nofail=>1 );
             my $fname = remove_leading_and_trailing_quotes( $nl->get_value($var) );
             if ( ! defined($nl->get_value($var))  ) {
-              fatal_error("$var is required when use_fates_lupft is set" );
+              $log->fatal_error("$var is required when use_fates_lupft is set" );
             } elsif ( ! -f "$fname" ) {
-              fatal_error("$fname does NOT point to a valid filename" );
+              $log->fatal_error("$fname does NOT point to a valid filename" );
             }
           }
           # make sure that nocomp and fbg mode are enabled as well as use_fates_luh
           my @list = ( "use_fates_nocomp", "use_fates_fixed_biogeog, use_fates_luh" );
           foreach my $var ( @list ) {
             if ( ! &value_is_true($nl->get_value($var)) ) {
-              fatal_error("$var is required when use_fates_lupft is true" );
+              $log->fatal_error("$var is required when use_fates_lupft is true" );
             }
           }
         }
@@ -4461,10 +4466,10 @@ sub setup_logic_fates {
         if ( defined($nl->get_value($var))  ) {
           if ( &value_is_true($nl->get_value($var)) ) {
             if ( ! &value_is_true($nl->get_value('use_fates_luh')) ) {
-              fatal_error("use_fates_luh must be true when $var is true" );
+              $log->fatal_error("use_fates_luh must be true when $var is true" );
             }
             if ( $nl->get_value('fates_harvest_mode') > 0) {
-              fatal_error("fates_harvest_mode must be off (i.e. set to zero) when $var is true" );
+              $log->fatal_error("fates_harvest_mode must be off (i.e. set to zero) when $var is true" );
             }
           }
         }
@@ -4475,17 +4480,17 @@ sub setup_logic_fates {
            # if ( $nl->get_value($var) == 2) {
            #    # Make sure that do_harvest is set to true
            #    if ( ! &value_is_true($nl->get_value('do_harvest')) ) {
-           #      fatal_error("do_harvest must be true when $var is equal to 2" );
+           #      $log->fatal_error("do_harvest must be true when $var is equal to 2" );
            # }
            # using fates_harvest mode with raw luh2 harvest data
            if ( $nl->get_value($var) > 2) {
               # Make sure that use_fates_luh is true when using raw fates luh2 harvest data
               if ( ! &value_is_true($nl->get_value('use_fates_luh')) ) {
-                fatal_error("use_fates_luh is required to be true when $var is greater than 2" );
+                $log->fatal_error("use_fates_luh is required to be true when $var is greater than 2" );
               }
               # do_harvest can not be on if we are using the raw fates luh2 harvest data
               if ( &value_is_true($nl->get_value('do_harvest')) ) {
-                fatal_error("do_harvest can not be true when $var is greater than 2" );
+                $log->fatal_error("do_harvest can not be true when $var is greater than 2" );
               }
            }
         }

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -4455,7 +4455,18 @@ sub setup_logic_fates {
               add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, $var, 'phys'=>$nl_flags->{'phys'}, 'hgrid'=>$nl_flags->{'res'}, 'sim_year_range'=>$nl_flags->{'sim_year_range'}, nofail=>1 );
            }
         }
-
+        # check that fates landuse is on and harvest mode is off when potential veg switch is true
+        my $var = "use_potentialveg";
+        if ( defined($nl->get_value($var))  ) {
+          if ( &value_is_true($nl->get_value($var)) ) {
+            if ( ! &value_is_true($nl->get_value('use_fates_luh')) ) {
+              fatal_error("use_fates_luh must be true when $var is true" );
+            }
+            if ( $nl->get_value('fates_harvest_mode') > 0) {
+              fatal_error("fates_harvest_mode must be off (i.e. set to zero) when $var is true" );
+            }
+          }
+        }
         # Check fates_harvest_mode compatibility
         my $var = "fates_harvest_mode";
         if ( defined($nl->get_value($var))  ) {

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -4379,7 +4379,8 @@ sub setup_logic_fates {
 
  	add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_lupft', 'use_fates'=>$nl_flags->{'use_fates'});
  	add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_luh', 'use_fates'=>$nl_flags->{'use_fates'},
-                      'use_fates_lupft'=>$nl->get_value('use_fates_lupft') );
+                      'use_fates_lupft'=>$nl->get_value('use_fates_lupft'), 
+                      'fates_harvest_mode'=>$nl->get_value('fates_harvest_mode') );
  	add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_nocomp', 'use_fates'=>$nl_flags->{'use_fates'},
                       'use_fates_lupft'=>$nl->get_value('use_fates_lupft'),
                       'use_fates_sp'=>$nl_flags->{'use_fates_sp'} );

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -4414,6 +4414,31 @@ sub setup_logic_fates {
               }
            }
         }
+        # make sure that fates landuse x pft mode has the necessary run mode configurations
+        # and add the necessary landuse x pft static mapping data default if not defined
+        my $var = "use_fates_lupft";
+        if ( defined($nl->get_value($var))  ) {
+          if ( &value_is_true($nl->get_value($var)) ) {
+            $var = "flandusepftdat";
+            add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, $var,
+                        'phys'=>$nl_flags->{'phys'}, 'hgrid'=>$nl_flags->{'res'}, nofail=>1 );
+            my $fname = remove_leading_and_trailing_quotes( $nl->get_value($var) );
+            if ( ! defined($nl->get_value($var))  ) {
+              fatal_error("$var is required when use_fates_lupft is set" );
+            } elsif ( ! -f "$fname" ) {
+              fatal_error("$fname does NOT point to a valid filename" );
+            }
+          }
+          # make sure that nocomp and fbg mode are enabled as well as use_fates_luh
+          my @list = ( "use_fates_nocomp", "use_fates_fixed_biogeog, use_fates_luh" );
+          foreach my $var ( @list ) {
+            if ( ! &value_is_true($nl->get_value($var)) ) {
+              fatal_error("$var is required when use_fates_lupft is true" );
+            }
+          }
+        }
+        # check that fates landuse change mode has the necessary luh2 landuse timeseries data
+        # and add the default if not defined
         my $var = "use_fates_luh";
         if ( defined($nl->get_value($var))  ) {
            if ( &value_is_true($nl->get_value($var)) ) {

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -4379,7 +4379,7 @@ sub setup_logic_fates {
 
  	add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_lupft', 'use_fates'=>$nl_flags->{'use_fates'});
  	add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_luh', 'use_fates'=>$nl_flags->{'use_fates'},
-                      'use_fates_lupft'=>$nl_flags->{'use_fates_lupft'} );
+                      'use_fates_lupft'=>$nl->get_value('use_fates_lupft') );
 
         my $suplnitro = $nl->get_value('suplnitro');
         my $parteh_mode = $nl->get_value('fates_parteh_mode');

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -785,7 +785,7 @@ sub setup_cmdl_fates_mode {
                       "use_fates_cohort_age_tracking","use_fates_inventory_init","use_fates_fixed_biogeog",
                       "use_fates_nocomp","use_fates_sp","fates_inventory_ctrl_filename","fates_harvest_mode",
                       "fates_parteh_mode","use_fates_tree_damage","fates_seeddisp_cadence","use_fates_luh","fluh_timeseries","flandusepftdat",
-                      "use_fates_potentialveg");
+                      "use_fates_potentialveg","use_fates_lupft");
        # dis-allow fates specific namelist items with non-fates runs
        foreach my $var ( @list ) {
           if ( defined($nl->get_value($var)) ) {
@@ -4371,7 +4371,8 @@ sub setup_logic_fates {
         add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'fates_paramfile', 'phys'=>$nl_flags->{'phys'});
         my @list  = (  "fates_spitfire_mode", "use_fates_planthydro", "use_fates_ed_st3", "use_fates_ed_prescribed_phys",
                        "use_fates_inventory_init","use_fates_fixed_biogeog","use_fates_nocomp","fates_seeddisp_cadence",
-                       "fates_harvest_mode","fates_parteh_mode", "use_fates_cohort_age_tracking","use_fates_tree_damage","use_fates_luh" );
+                       "fates_harvest_mode","fates_parteh_mode", "use_fates_cohort_age_tracking","use_fates_tree_damage",
+                       "use_fates_luh","use_fates_lupft" );
         foreach my $var ( @list ) {
  	  add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, $var, 'use_fates'=>$nl_flags->{'use_fates'},
                       'use_fates_sp'=>$nl_flags->{'use_fates_sp'} );

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -4370,7 +4370,7 @@ sub setup_logic_fates {
     if (&value_is_true( $nl_flags->{'use_fates'})  ) {
         add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'fates_paramfile', 'phys'=>$nl_flags->{'phys'});
         my @list  = (  "fates_spitfire_mode", "use_fates_planthydro", "use_fates_ed_st3", "use_fates_ed_prescribed_phys",
-                       "use_fates_inventory_init","use_fates_fixed_biogeog","use_fates_nocomp","fates_seeddisp_cadence",
+                       "use_fates_inventory_init","fates_seeddisp_cadence",
                        "fates_harvest_mode","fates_parteh_mode", "use_fates_cohort_age_tracking","use_fates_tree_damage");
         foreach my $var ( @list ) {
  	  add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, $var, 'use_fates'=>$nl_flags->{'use_fates'},
@@ -4380,6 +4380,12 @@ sub setup_logic_fates {
  	add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_lupft', 'use_fates'=>$nl_flags->{'use_fates'});
  	add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_luh', 'use_fates'=>$nl_flags->{'use_fates'},
                       'use_fates_lupft'=>$nl->get_value('use_fates_lupft') );
+ 	add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_nocomp', 'use_fates'=>$nl_flags->{'use_fates'},
+                      'use_fates_lupft'=>$nl->get_value('use_fates_lupft'),
+                      'use_fates_sp'=>$nl_flags->{'use_fates_sp'} );
+ 	add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_fixed_biogeog', 'use_fates'=>$nl_flags->{'use_fates'},
+                      'use_fates_lupft'=>$nl->get_value('use_fates_lupft'),
+                      'use_fates_sp'=>$nl_flags->{'use_fates_sp'} );
 
         my $suplnitro = $nl->get_value('suplnitro');
         my $parteh_mode = $nl->get_value('fates_parteh_mode');
@@ -4435,7 +4441,7 @@ sub setup_logic_fates {
             }
 
             # make sure that nocomp and fbg mode are enabled as well as use_fates_luh
-            my @list = ( "use_fates_nocomp", "use_fates_fixed_biogeog, use_fates_luh" );
+            my @list = ( "use_fates_luh", "use_fates_nocomp", "use_fates_fixed_biogeog" );
             foreach my $var ( @list ) {
               if ( ! &value_is_true($nl->get_value($var)) ) {
                 $log->fatal_error("$var is required when use_fates_lupft is true" );

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -4377,9 +4377,11 @@ sub setup_logic_fates {
                       'use_fates_sp'=>$nl_flags->{'use_fates_sp'} );
         }
 
+ 	add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_potentialveg', 'use_fates'=>$nl_flags->{'use_fates'});
  	add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_lupft', 'use_fates'=>$nl_flags->{'use_fates'});
  	add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_luh', 'use_fates'=>$nl_flags->{'use_fates'},
                       'use_fates_lupft'=>$nl->get_value('use_fates_lupft'), 
+                      'use_fates_potentialveg'=>$nl->get_value('use_fates_potentialveg'), 
                       'fates_harvest_mode'=>$nl->get_value('fates_harvest_mode') );
  	add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_nocomp', 'use_fates'=>$nl_flags->{'use_fates'},
                       'use_fates_lupft'=>$nl->get_value('use_fates_lupft'),
@@ -4466,7 +4468,7 @@ sub setup_logic_fates {
            }
         }
         # check that fates landuse is on and harvest mode is off when potential veg switch is true
-        my $var = "use_potentialveg";
+        my $var = "use_fates_potentialveg";
         if ( defined($nl->get_value($var))  ) {
           if ( &value_is_true($nl->get_value($var)) ) {
             if ( ! &value_is_true($nl->get_value('use_fates_luh')) ) {

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -4414,6 +4414,10 @@ sub setup_logic_fates {
               if ( $nl->get_value('fates_spitfire_mode') > 0 ) {
                     $log->fatal_error('fates_spitfire_mode can NOT be set to greater than 0 when use_fates_sp is true');
               }
+              # fates landuse can't be on with FATES SP mode is active
+              if ( &value_is_true($nl->get_value('use_fates_luh')) ) {
+                    $log->fatal_error('use_fates_luh can NOT be true when use_fates_sp is true');
+              }
            }
         }
         my $var = "use_fates_inventory_init";

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -2769,7 +2769,8 @@ use_crop=".true.">lnd/clm2/surfdata_map/ctsm5.1.dev052/landuse.timeseries_mpasa1
 <use_fates_sp                  use_fates=".true.">.false.</use_fates_sp>
 <use_fates_lupft               use_fates=".true.">.false.</use_fates_lupft>
 <use_fates_potentialveg        use_fates=".true.">.false.</use_fates_potentialveg>
-<use_fates_luh                 use_fates=".true.">.false.</use_fates_luh>
+<use_fates_luh                 use_fates=".true." use_fates_lupft=".true.">.true.</use_fates_luh>
+<use_fates_luh                 use_fates=".true."                         >.false.</use_fates_luh>
 <fates_parteh_mode             use_fates=".true.">1</fates_parteh_mode>
 <fates_seeddisp_cadence        use_fates=".true.">0</fates_seeddisp_cadence>
 <use_fates_nocomp              use_fates=".true." use_fates_sp=".true."   >.true.</use_fates_nocomp>

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -2769,10 +2769,11 @@ use_crop=".true.">lnd/clm2/surfdata_map/ctsm5.1.dev052/landuse.timeseries_mpasa1
 <use_fates_sp                  use_fates=".true.">.false.</use_fates_sp>
 <use_fates_lupft               use_fates=".true.">.false.</use_fates_lupft>
 <use_fates_potentialveg        use_fates=".true.">.false.</use_fates_potentialveg>
-<use_fates_luh                 use_fates=".true." fates_harvest_mode="3"  >.true.</use_fates_luh>
-<use_fates_luh                 use_fates=".true." fates_harvest_mode="4"  >.true.</use_fates_luh>
-<use_fates_luh                 use_fates=".true." use_fates_lupft=".true.">.true.</use_fates_luh>
-<use_fates_luh                 use_fates=".true."                         >.false.</use_fates_luh>
+<use_fates_luh                 use_fates=".true." fates_harvest_mode="3"         >.true.</use_fates_luh>
+<use_fates_luh                 use_fates=".true." fates_harvest_mode="4"         >.true.</use_fates_luh>
+<use_fates_luh                 use_fates=".true." use_fates_lupft=".true."       >.true.</use_fates_luh>
+<use_fates_luh                 use_fates=".true." use_fates_potentialveg=".true.">.true.</use_fates_luh>
+<use_fates_luh                 use_fates=".true."                                >.false.</use_fates_luh>
 <fates_parteh_mode             use_fates=".true.">1</fates_parteh_mode>
 <fates_seeddisp_cadence        use_fates=".true.">0</fates_seeddisp_cadence>
 

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -2769,19 +2769,16 @@ use_crop=".true.">lnd/clm2/surfdata_map/ctsm5.1.dev052/landuse.timeseries_mpasa1
 <use_fates_sp                  use_fates=".true.">.false.</use_fates_sp>
 <use_fates_lupft               use_fates=".true.">.false.</use_fates_lupft>
 <use_fates_potentialveg        use_fates=".true.">.false.</use_fates_potentialveg>
-<use_fates_luh                 use_fates=".true." fates_harvest_mode="3"         >.true.</use_fates_luh>
-<use_fates_luh                 use_fates=".true." fates_harvest_mode="4"         >.true.</use_fates_luh>
+
 <use_fates_luh                 use_fates=".true." use_fates_lupft=".true."       >.true.</use_fates_luh>
-<use_fates_luh                 use_fates=".true." use_fates_potentialveg=".true.">.true.</use_fates_luh>
 <use_fates_luh                 use_fates=".true."                                >.false.</use_fates_luh>
+
 <fates_parteh_mode             use_fates=".true.">1</fates_parteh_mode>
 <fates_seeddisp_cadence        use_fates=".true.">0</fates_seeddisp_cadence>
 
 <use_fates_nocomp              use_fates=".true." use_fates_sp=".true."   >.true.</use_fates_nocomp>
-<use_fates_nocomp              use_fates=".true." use_fates_lupft=".true.">.true.</use_fates_nocomp>
 <use_fates_nocomp              use_fates=".true."                         >.false.</use_fates_nocomp>
 <use_fates_fixed_biogeog       use_fates=".true." use_fates_sp=".true."   >.true.</use_fates_fixed_biogeog>
-<use_fates_fixed_biogeog       use_fates=".true." use_fates_lupft=".true.">.true.</use_fates_fixed_biogeog>
 <use_fates_fixed_biogeog       use_fates=".true."                         >.false.</use_fates_fixed_biogeog>
 
 <!-- =========================================  -->

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -2769,6 +2769,8 @@ use_crop=".true.">lnd/clm2/surfdata_map/ctsm5.1.dev052/landuse.timeseries_mpasa1
 <use_fates_sp                  use_fates=".true.">.false.</use_fates_sp>
 <use_fates_lupft               use_fates=".true.">.false.</use_fates_lupft>
 <use_fates_potentialveg        use_fates=".true.">.false.</use_fates_potentialveg>
+<use_fates_luh                 use_fates=".true." fates_harvest_mode="3">.true.</use_fates_luh>
+<use_fates_luh                 use_fates=".true." fates_harvest_mode="4">.true.</use_fates_luh>
 <use_fates_luh                 use_fates=".true." use_fates_lupft=".true.">.true.</use_fates_luh>
 <use_fates_luh                 use_fates=".true."                         >.false.</use_fates_luh>
 <fates_parteh_mode             use_fates=".true.">1</fates_parteh_mode>

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -2769,10 +2769,11 @@ use_crop=".true.">lnd/clm2/surfdata_map/ctsm5.1.dev052/landuse.timeseries_mpasa1
 <use_fates_sp                  use_fates=".true.">.false.</use_fates_sp>
 <use_fates_lupft               use_fates=".true.">.false.</use_fates_lupft>
 <use_fates_potentialveg        use_fates=".true.">.false.</use_fates_potentialveg>
-<use_fates_luh                 use_fates=".true." fates_harvest_mode="3">.true.</use_fates_luh>
-<use_fates_luh                 use_fates=".true." fates_harvest_mode="4">.true.</use_fates_luh>
+<use_fates_luh                 use_fates=".true." fates_harvest_mode="3"  >.true.</use_fates_luh>
+<use_fates_luh                 use_fates=".true." fates_harvest_mode="4"  >.true.</use_fates_luh>
 <use_fates_luh                 use_fates=".true." use_fates_lupft=".true.">.true.</use_fates_luh>
-<use_fates_luh                 use_fates=".true."                         >.false.</use_fates_luh>
+<use_fates_luh                 use_fates=".true." use_fates_potentialveg=".true.">.true.</use_fates_luh>
+<use_fates_luh                 use_fates=".true."                                >.false.</use_fates_luh>
 <fates_parteh_mode             use_fates=".true.">1</fates_parteh_mode>
 <fates_seeddisp_cadence        use_fates=".true.">0</fates_seeddisp_cadence>
 <use_fates_nocomp              use_fates=".true." use_fates_sp=".true."   >.true.</use_fates_nocomp>

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -2774,8 +2774,10 @@ use_crop=".true.">lnd/clm2/surfdata_map/ctsm5.1.dev052/landuse.timeseries_mpasa1
 <fates_parteh_mode             use_fates=".true.">1</fates_parteh_mode>
 <fates_seeddisp_cadence        use_fates=".true.">0</fates_seeddisp_cadence>
 <use_fates_nocomp              use_fates=".true." use_fates_sp=".true."   >.true.</use_fates_nocomp>
+<use_fates_nocomp              use_fates=".true." use_fates_lupft=".true.">.true.</use_fates_nocomp>
 <use_fates_nocomp              use_fates=".true."                         >.false.</use_fates_nocomp>
 <use_fates_fixed_biogeog       use_fates=".true." use_fates_sp=".true."   >.true.</use_fates_fixed_biogeog>
+<use_fates_fixed_biogeog       use_fates=".true." use_fates_lupft=".true.">.true.</use_fates_fixed_biogeog>
 <use_fates_fixed_biogeog       use_fates=".true."                         >.false.</use_fates_fixed_biogeog>
 
 <!-- =========================================  -->

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -2769,13 +2769,9 @@ use_crop=".true.">lnd/clm2/surfdata_map/ctsm5.1.dev052/landuse.timeseries_mpasa1
 <use_fates_sp                  use_fates=".true.">.false.</use_fates_sp>
 <use_fates_lupft               use_fates=".true.">.false.</use_fates_lupft>
 <use_fates_potentialveg        use_fates=".true.">.false.</use_fates_potentialveg>
-
-<use_fates_luh                 use_fates=".true." use_fates_lupft=".true."       >.true.</use_fates_luh>
-<use_fates_luh                 use_fates=".true."                                >.false.</use_fates_luh>
-
+<use_fates_luh                 use_fates=".true.">.false.</use_fates_luh>
 <fates_parteh_mode             use_fates=".true.">1</fates_parteh_mode>
 <fates_seeddisp_cadence        use_fates=".true.">0</fates_seeddisp_cadence>
-
 <use_fates_nocomp              use_fates=".true." use_fates_sp=".true."   >.true.</use_fates_nocomp>
 <use_fates_nocomp              use_fates=".true."                         >.false.</use_fates_nocomp>
 <use_fates_fixed_biogeog       use_fates=".true." use_fates_sp=".true."   >.true.</use_fates_fixed_biogeog>

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -2767,17 +2767,21 @@ use_crop=".true.">lnd/clm2/surfdata_map/ctsm5.1.dev052/landuse.timeseries_mpasa1
 <use_fates_ed_prescribed_phys  use_fates=".true.">.false.</use_fates_ed_prescribed_phys>
 <use_fates_inventory_init      use_fates=".true.">.false.</use_fates_inventory_init>
 <use_fates_sp                  use_fates=".true.">.false.</use_fates_sp>
+<use_fates_lupft               use_fates=".true.">.false.</use_fates_lupft>
 <use_fates_potentialveg        use_fates=".true.">.false.</use_fates_potentialveg>
-<use_fates_luh                 use_fates=".true." fates_harvest_mode="3">.true.</use_fates_luh>
-<use_fates_luh                 use_fates=".true." fates_harvest_mode="4">.true.</use_fates_luh>
-<use_fates_luh                 use_fates=".true.">.false.</use_fates_luh>
+<use_fates_luh                 use_fates=".true." fates_harvest_mode="3"  >.true.</use_fates_luh>
+<use_fates_luh                 use_fates=".true." fates_harvest_mode="4"  >.true.</use_fates_luh>
+<use_fates_luh                 use_fates=".true." use_fates_lupft=".true.">.true.</use_fates_luh>
+<use_fates_luh                 use_fates=".true."                         >.false.</use_fates_luh>
 <fates_parteh_mode             use_fates=".true.">1</fates_parteh_mode>
 <fates_seeddisp_cadence        use_fates=".true.">0</fates_seeddisp_cadence>
 
-<use_fates_nocomp              use_fates=".true." use_fates_sp=".true.">.true.</use_fates_nocomp>
-<use_fates_nocomp              use_fates=".true."                      >.false.</use_fates_nocomp>
-<use_fates_fixed_biogeog       use_fates=".true." use_fates_sp=".true.">.true.</use_fates_fixed_biogeog>
-<use_fates_fixed_biogeog       use_fates=".true."                      >.false.</use_fates_fixed_biogeog>
+<use_fates_nocomp              use_fates=".true." use_fates_sp=".true."   >.true.</use_fates_nocomp>
+<use_fates_nocomp              use_fates=".true." use_fates_lupft=".true.">.true.</use_fates_nocomp>
+<use_fates_nocomp              use_fates=".true."                         >.false.</use_fates_nocomp>
+<use_fates_fixed_biogeog       use_fates=".true." use_fates_sp=".true."   >.true.</use_fates_fixed_biogeog>
+<use_fates_fixed_biogeog       use_fates=".true." use_fates_lupft=".true.">.true.</use_fates_fixed_biogeog>
+<use_fates_fixed_biogeog       use_fates=".true."                         >.false.</use_fates_fixed_biogeog>
 
 <!-- =========================================  -->
 <!-- Defaults for dynamic subgrid               -->

--- a/bld/namelist_files/namelist_definition_ctsm.xml
+++ b/bld/namelist_files/namelist_definition_ctsm.xml
@@ -791,6 +791,12 @@ data (fates_harvest_mode >= 3)
 (Also, only valid for use_fates = true and is incompatible with transient runs currently.)
 </entry>
 
+<entry id="use_fates_lupft" type="logical" category="physics"
+       group="elm_inparm" valid_values="" value=".false.">
+If TRUE, enable use of fates land use x pft mapping data file.
+(Only valid for use_fates = true and is incompatible with transient runs currently.)
+</entry>
+
 <entry id="use_fates_potentialveg" type="logical" category="physics"
        group="clm_inparm" valid_values="" >
 If TRUE, ignore the land-use state vector and transitions, and assert that all lands

--- a/bld/namelist_files/namelist_definition_ctsm.xml
+++ b/bld/namelist_files/namelist_definition_ctsm.xml
@@ -814,7 +814,7 @@ types to vary over time.
 
 <entry id="flandusepftdat" type="char*256" category="datasets"
        input_pathname="abs" group="clm_inparm" valid_values="" >
-Full pathname of fates landuse x pft data map.
+Full pathname of fates landuse x pft static data map.
 </entry>
 
 <entry id="use_luna" type="logical" category="physics"

--- a/bld/unit_testers/build-namelist_test.pl
+++ b/bld/unit_testers/build-namelist_test.pl
@@ -163,10 +163,10 @@ my $testType="namelistTest";
 #
 # Figure out number of tests that will run
 #
-my $ntests = 1999;
+my $ntests = 2006;
 
 if ( defined($opts{'compare'}) ) {
-   $ntests += 1353;
+   $ntests += 1360;
 }
 plan( tests=>$ntests );
 
@@ -1062,8 +1062,13 @@ my %failtest = (
                                      GLC_TWO_WAY_COUPLING=>"FALSE",
                                      phys=>"clm4_5",
                                    },
-     "useLUH2butnotfile"         =>{ options=>"--res 0.9x1.25 --bgc fates --envxml_dir . --no-megan",
+     "useFATESLUH2butnotfile"    =>{ options=>"--res 0.9x1.25 --bgc fates --envxml_dir . --no-megan",
                                      namelst=>"use_fates_luh=.true.",
+                                     GLC_TWO_WAY_COUPLING=>"FALSE",
+                                     phys=>"clm4_5",
+                                   },
+     "useFATESLUPFTbutnotfile"   =>{ options=>"--res 0.9x1.25 --bgc fates --envxml_dir . --no-megan",
+                                     namelst=>"use_fates_lupft=.true.",
                                      GLC_TWO_WAY_COUPLING=>"FALSE",
                                      phys=>"clm4_5",
                                    },
@@ -1089,6 +1094,36 @@ my %failtest = (
                                    },
      "useFATESSPWONOCOMP"        =>{ options=>"-bgc fates -envxml_dir . -no-megan",
                                      namelst=>"use_fates_sp=T,use_fates_nocomp=F",
+                                     GLC_TWO_WAY_COUPLING=>"FALSE",
+                                     phys=>"clm5_0",
+                                   },
+     "useFATESSPwithLUH"        =>{ options=>"-bgc fates -envxml_dir . -no-megan",
+                                     namelst=>"use_fates_sp=T,use_fates_luh=T",
+                                     GLC_TWO_WAY_COUPLING=>"FALSE",
+                                     phys=>"clm5_0",
+                                   },
+     "useFATESPOTVEGwithHARVEST" =>{ options=>"-bgc fates -envxml_dir . -no-megan",
+                                     namelst=>"use_fates_potentialveg=T,fates_harvest_mode=1",
+                                     GLC_TWO_WAY_COUPLING=>"FALSE",
+                                     phys=>"clm5_0",
+                                   },
+     "useFATESHARVEST3WOLUH"     =>{ options=>"-bgc fates -envxml_dir . -no-megan",
+                                     namelst=>"use_fates_luh=F,fates_harvest_mode=3",
+                                     GLC_TWO_WAY_COUPLING=>"FALSE",
+                                     phys=>"clm5_0",
+                                   },
+     "useFATESLUPFTWOLUH"        =>{ options=>"-bgc fates -envxml_dir . -no-megan",
+                                     namelst=>"use_fates_lupft=T,use_fates_luh=F",
+                                     GLC_TWO_WAY_COUPLING=>"FALSE",
+                                     phys=>"clm5_0",
+                                   },
+     "useFATESLUPFTWONOCOMP"     =>{ options=>"-bgc fates -envxml_dir . -no-megan",
+                                     namelst=>"use_fates_lupft=T,use_fates_nocomp=F",
+                                     GLC_TWO_WAY_COUPLING=>"FALSE",
+                                     phys=>"clm5_0",
+                                   },
+     "useFATESLUPFTWOFBG"        =>{ options=>"-bgc fates -envxml_dir . -no-megan",
+                                     namelst=>"use_fates_lupft=T,use_fates_fixedbiogeog=F",
                                      GLC_TWO_WAY_COUPLING=>"FALSE",
                                      phys=>"clm5_0",
                                    },

--- a/bld/unit_testers/build-namelist_test.pl
+++ b/bld/unit_testers/build-namelist_test.pl
@@ -1046,9 +1046,8 @@ my %failtest = (
                                      GLC_TWO_WAY_COUPLING=>"FALSE",
                                      phys=>"clm4_5",
                                    },
-     # TODO SSR: Replace this with fates_harvest_mode
      "useloggingButNOTFATES"     =>{ options=>"-envxml_dir . -no-megan",
-                                     namelst=>"use_fates_logging=.true.",
+                                     namelst=>"fates_harvest_mode=1",
                                      GLC_TWO_WAY_COUPLING=>"FALSE",
                                      phys=>"clm4_5",
                                    },

--- a/bld/unit_testers/build-namelist_test.pl
+++ b/bld/unit_testers/build-namelist_test.pl
@@ -1062,7 +1062,7 @@ my %failtest = (
                                      GLC_TWO_WAY_COUPLING=>"FALSE",
                                      phys=>"clm4_5",
                                    },
-     "useinventorybutnotfile"    =>{ options=>"--res 0.9x1.25 --bgc fates --envxml_dir . --no-megan",
+     "useLUH2butnotfile"         =>{ options=>"--res 0.9x1.25 --bgc fates --envxml_dir . --no-megan",
                                      namelst=>"use_fates_luh=.true.",
                                      GLC_TWO_WAY_COUPLING=>"FALSE",
                                      phys=>"clm4_5",

--- a/bld/unit_testers/build-namelist_test.pl
+++ b/bld/unit_testers/build-namelist_test.pl
@@ -163,7 +163,7 @@ my $testType="namelistTest";
 #
 # Figure out number of tests that will run
 #
-my $ntests = 2006;
+my $ntests = 2007;
 
 if ( defined($opts{'compare'}) ) {
    $ntests += 1360;

--- a/src/main/clm_varctl.F90
+++ b/src/main/clm_varctl.F90
@@ -311,6 +311,7 @@ module clm_varctl
   logical, public            :: use_fates_fixed_biogeog = .false.       ! true => use fixed biogeography mode
   logical, public            :: use_fates_nocomp = .false.              ! true => use no comopetition mode
   logical, public            :: use_fates_luh = .false.                 ! true => use FATES landuse data mode
+  logical, public            :: use_fates_lupft = .false.               ! true => use FATES landuse x pft static mapping mode
   logical, public            :: use_fates_potentialveg = .false.        ! true => FATES potential veg only
   character(len=256), public :: fluh_timeseries = ''                    ! filename for fates landuse timeseries data
   character(len=256), public :: flandusepftdat = ''                     ! filename for fates landuse x pft data

--- a/src/main/controlMod.F90
+++ b/src/main/controlMod.F90
@@ -231,6 +231,7 @@ contains
           use_fates_nocomp,                             &
           use_fates_sp,                                 &
           use_fates_luh,                                &
+          use_fates_lupft,                              &
           use_fates_potentialveg,                       &
           fluh_timeseries,                              &
           flandusepftdat,                               &
@@ -785,6 +786,7 @@ contains
     call mpi_bcast (use_fates_nocomp, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_fates_sp, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_fates_luh, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (use_fates_lupft, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_fates_potentialveg, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (use_fates_bgc, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (fates_inventory_ctrl_filename, len(fates_inventory_ctrl_filename), MPI_CHARACTER, 0, mpicom, ier)
@@ -1161,6 +1163,7 @@ contains
        write(iulog, *) '    use_fates_nocomp = ', use_fates_nocomp
        write(iulog, *) '    use_fates_sp = ', use_fates_sp
        write(iulog, *) '    use_fates_luh= ', use_fates_luh
+       write(iulog, *) '    use_fates_lupft= ', use_fates_lupft
        write(iulog, *) '    use_fates_potentialveg = ', use_fates_potentialveg
        write(iulog, *) '    fluh_timeseries = ', trim(fluh_timeseries)
        write(iulog, *) '    flandusepftdat = ', trim(flandusepftdat)

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -398,7 +398,6 @@ module CLMFatesInterfaceMod
      integer                                        :: pass_use_potentialveg
      integer                                        :: pass_num_luh_states
      integer                                        :: pass_num_luh_transitions
-     integer                                        :: pass_lupftdat
 
      call t_startf('fates_globals2')
 
@@ -704,7 +703,7 @@ module CLMFatesInterfaceMod
       end if
 
       ! Retrieve the landuse x pft static data if the file is present
-      if (use_fates_lupft) then
+      if (use_fates_fixed_biogeog .and. use_fates_luh) then
          call GetLandusePFTData(bounds_proc, flandusepftdat, landuse_pft_map, landuse_bareground)
       end if
 
@@ -815,23 +814,23 @@ module CLMFatesInterfaceMod
             this%fates(nc)%sites(s)%lon = grc%londeg(g)
 
             ! Transfer the landuse x pft data to fates via bc_in if file is given
-            if (use_fates_lupft) then
-               this%fates(nc)%bc_in(s)%pft_areafrac_lu(:,1:num_landuse_pft_vars) = landuse_pft_map(g,:,1:num_landuse_pft_vars)
-               this%fates(nc)%bc_in(s)%baregroundfrac = landuse_bareground(g)
-            end if
+            if (use_fates_fixed_biogeog) then
+               if (use_fates_luh) then
+                  this%fates(nc)%bc_in(s)%pft_areafrac_lu(:,1:num_landuse_pft_vars) = landuse_pft_map(g,:,1:num_landuse_pft_vars)
+                  this%fates(nc)%bc_in(s)%baregroundfrac = landuse_bareground(g)
+               else
+                  ! initialize static layers for reduced complexity FATES versions from HLM
+                  ! maybe make this into a subroutine of it's own later.
+                  this%fates(nc)%bc_in(s)%pft_areafrac(:)=0._r8
+                  do m = surfpft_lb,surfpft_ub
+                     ft = m - surfpft_lb
+                     this%fates(nc)%bc_in(s)%pft_areafrac(ft)=wt_nat_patch(g,m)
+                  end do
 
-            if (.not. use_fates_lupft) then
-               ! initialize static layers for reduced complexity FATES versions from HLM
-               ! maybe make this into a subroutine of it's own later.
-               this%fates(nc)%bc_in(s)%pft_areafrac(:)=0._r8
-               do m = surfpft_lb,surfpft_ub
-                  ft = m - surfpft_lb
-                  this%fates(nc)%bc_in(s)%pft_areafrac(ft)=wt_nat_patch(g,m)
-               end do
-
-               if (abs(sum(this%fates(nc)%bc_in(s)%pft_areafrac(surfpft_lb:surfpft_ub)) - 1.0_r8) >    sum_to_1_tol) then
-                  write(iulog,*) 'pft_area error in interfc ', s, sum(this%fates(nc)%bc_in(s)   %pft_areafrac(:)) - 1.0_r8
-                  call endrun(msg=errMsg(sourcefile, __LINE__))
+                  if (abs(sum(this%fates(nc)%bc_in(s)%pft_areafrac(surfpft_lb:surfpft_ub)) - 1.0_r8) >    sum_to_1_tol) then
+                     write(iulog,*) 'pft_area error in interfc ', s, sum(this%fates(nc)%bc_in(s)   %pft_areafrac(:)) - 1.0_r8
+                     call endrun(msg=errMsg(sourcefile, __LINE__))
+                  end if
                end if
             end if
           end do !site
@@ -876,7 +875,7 @@ module CLMFatesInterfaceMod
       call create_fates_fire_data_method( this%fates_fire_data_method )
 
       ! deallocate the local landuse x pft array
-      if (use_fates_lupft) then
+      if (use_fates_fixed_biogeog .and. use_fates_luh) then
          deallocate(landuse_pft_map)
          deallocate(landuse_bareground)
       end if

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -60,6 +60,7 @@ module CLMFatesInterfaceMod
    use clm_varctl        , only : use_fates_nocomp
    use clm_varctl        , only : use_fates_sp
    use clm_varctl        , only : use_fates_luh
+   use clm_varctl        , only : use_fates_lupft
    use clm_varctl        , only : use_fates_potentialveg
    use clm_varctl        , only : flandusepftdat
    use clm_varctl        , only : fates_seeddisp_cadence
@@ -567,13 +568,6 @@ module CLMFatesInterfaceMod
         end if
         call set_fates_ctrlparms('use_fates_potentialveg',ival=pass_use_potentialveg)
 
-        if(flandusepftdat /= '') then
-           pass_lupftdat = 1
-        else
-           pass_lupftdat = 0
-        end if
-        call set_fates_ctrlparms('use_landusepft_data',ival=pass_lupftdat)
-
         ! Wait to set the harvest and logging variables after checking get_do_harvest
         ! and fates_harvest_modes
         call set_fates_ctrlparms('use_lu_harvest',ival=pass_lu_harvest)
@@ -710,7 +704,7 @@ module CLMFatesInterfaceMod
       end if
 
       ! Retrieve the landuse x pft static data if the file is present
-      if (flandusepftdat /= '') then
+      if (use_fates_lupft) then
          call GetLandusePFTData(bounds_proc, flandusepftdat, landuse_pft_map, landuse_bareground)
       end if
 
@@ -821,12 +815,12 @@ module CLMFatesInterfaceMod
             this%fates(nc)%sites(s)%lon = grc%londeg(g)
 
             ! Transfer the landuse x pft data to fates via bc_in if file is given
-            if (flandusepftdat /= '') then
+            if (use_fates_lupft) then
                this%fates(nc)%bc_in(s)%pft_areafrac_lu(:,1:num_landuse_pft_vars) = landuse_pft_map(g,:,1:num_landuse_pft_vars)
                this%fates(nc)%bc_in(s)%baregroundfrac = landuse_bareground(g)
             end if
 
-            if (flandusepftdat == '') then
+            if (.not. use_fates_lupft) then
                ! initialize static layers for reduced complexity FATES versions from HLM
                ! maybe make this into a subroutine of it's own later.
                this%fates(nc)%bc_in(s)%pft_areafrac(:)=0._r8
@@ -882,7 +876,7 @@ module CLMFatesInterfaceMod
       call create_fates_fire_data_method( this%fates_fire_data_method )
 
       ! deallocate the local landuse x pft array
-      if (flandusepftdat /= '') then
+      if (use_fates_lupft) then
          deallocate(landuse_pft_map)
          deallocate(landuse_bareground)
       end if


### PR DESCRIPTION
### Description of changes
This ports changes made via https://github.com/glemieux/E3SM/tree/landuse-v2-modechecks to ctsm.

### Specific notes
This adds a new switch `use_fates_lupft` to replace the previous checks on `flandusepftdat` as well as adding new namelist build checks for valid fates run mode combinations including `use_potentialveg`.

Contributors other than yourself, if any: @ckoven

Testing performed, if any:
**Build and run testing TBD**