### PR TITLE
Remove fates dependency on `do_harvest`

### DIFF
--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -2932,7 +2932,7 @@ sub setup_logic_do_harvest {
          $cannot_be_true = "$var can only be set to true when running a transient case (flanduse_timeseries non-blank)";
       }
 
-      elsif (!&value_is_true($nl->get_value('use_cn')) && !&value_is_true($nl->get_value('use_fates'))) {
+      elsif (!&value_is_true($nl->get_value('use_cn')) && &value_is_true($nl->get_value('use_fates'))) {
          $cannot_be_true = "$var can only be set to true when running with either CN or FATES";
       }
 
@@ -4486,21 +4486,11 @@ sub setup_logic_fates {
         # Check fates_harvest_mode compatibility
         my $var = "fates_harvest_mode";
         if ( defined($nl->get_value($var))  ) {
-           # using fates_harvest_mode with CLM landuse driver data - for user convienence
-           # if ( $nl->get_value($var) == 2) {
-           #    # Make sure that do_harvest is set to true
-           #    if ( ! &value_is_true($nl->get_value('do_harvest')) ) {
-           #      $log->fatal_error("do_harvest must be true when $var is equal to 2" );
-           # }
            # using fates_harvest mode with raw luh2 harvest data
            if ( $nl->get_value($var) > 2) {
               # Make sure that use_fates_luh is true when using raw fates luh2 harvest data
               if ( ! &value_is_true($nl->get_value('use_fates_luh')) ) {
                 $log->fatal_error("use_fates_luh is required to be true when $var is greater than 2" );
-              }
-              # do_harvest can not be on if we are using the raw fates luh2 harvest data
-              if ( &value_is_true($nl->get_value('do_harvest')) ) {
-                $log->fatal_error("do_harvest can not be true when $var is greater than 2" );
               }
            }
         }

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -2932,8 +2932,8 @@ sub setup_logic_do_harvest {
          $cannot_be_true = "$var can only be set to true when running a transient case (flanduse_timeseries non-blank)";
       }
 
-      elsif (!&value_is_true($nl->get_value('use_cn')) && &value_is_true($nl->get_value('use_fates'))) {
-         $cannot_be_true = "$var can only be set to true when running with either CN or FATES";
+      elsif (!&value_is_true($nl->get_value('use_cn'))) {
+         $cannot_be_true = "$var can only be set to true when running with CN.  Please set use_cn to true.";
       }
 
       if ($cannot_be_true) {

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -4433,21 +4433,9 @@ sub setup_logic_fates {
            }
         }
         # make sure that fates landuse x pft mode has the necessary run mode configurations
-        # and add the necessary landuse x pft static mapping data default if not defined
         my $var = "use_fates_lupft";
         if ( defined($nl->get_value($var))  ) {
           if ( &value_is_true($nl->get_value($var)) ) {
-            $var = "flandusepftdat";
-            add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, $var,
-                        'phys'=>$nl_flags->{'phys'}, 'hgrid'=>$nl_flags->{'res'}, nofail=>1 );
-            my $fname = remove_leading_and_trailing_quotes( $nl->get_value($var) );
-            if ( ! defined($nl->get_value($var))  ) {
-              $log->fatal_error("$var is required when use_fates_lupft is set" );
-            } elsif ( ! -f "$fname" ) {
-              $log->fatal_error("$fname does NOT point to a valid filename" );
-            }
-
-            # make sure that nocomp and fbg mode are enabled as well as use_fates_luh
             my @list = ( "use_fates_luh", "use_fates_nocomp", "use_fates_fixed_biogeog" );
             foreach my $var ( @list ) {
               if ( ! &value_is_true($nl->get_value($var)) ) {
@@ -4457,31 +4445,56 @@ sub setup_logic_fates {
           }
         }
         # check that fates landuse change mode has the necessary luh2 landuse timeseries data
-        # and add the default if not defined
+        # and add the default if not defined.  Do not add default if use_fates_potentialveg is true.
+        # If fixed biogeography is on, make sure that flandusepftdat is avilable.
         my $var = "use_fates_luh";
         if ( defined($nl->get_value($var))  ) {
            if ( &value_is_true($nl->get_value($var)) ) {
-              $var = "fluh_timeseries";
-              add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, $var, 'phys'=>$nl_flags->{'phys'}, 'hgrid'=>$nl_flags->{'res'}, 'sim_year_range'=>$nl_flags->{'sim_year_range'}, nofail=>1 );
-              my $fname = remove_leading_and_trailing_quotes( $nl->get_value($var) );
-              if ( ! defined($nl->get_value($var))  ) {
-                 $log->fatal_error("$var is required when use_fates_luh is set" );
-              } elsif ( ! -f "$fname" ) {
-                 $log->fatal_error("$fname does NOT point to a valid filename" );
-              }
+              $var = "use_fates_potentialveg";
+              if ( defined($nl->get_value($var))  ) {
+                 if ( ! &value_is_true($nl->get_value($var)) ) {
+                    $var = "fluh_timeseries";
+                    add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, $var, 'phys'=>$nl_flags->{'phys'}, 
+           			'hgrid'=>$nl_flags->{'res'}, 'sim_year_range'=>$nl_flags->{'sim_year_range'}, nofail=>1 );
+                    my $fname = remove_leading_and_trailing_quotes( $nl->get_value($var) );
+                    if ( ! defined($nl->get_value($var))  ) {
+                       $log->fatal_error("$var is required when use_fates_luh is set and use_fates_potentialveg is false" );
+                    } elsif ( ! -f "$fname" ) {
+                       $log->fatal_error("$var does NOT point to a valid filename" );
+                    }
+                 }
+	      }
+              $var = "use_fates_fixed_biogeog";
+              if ( defined($nl->get_value($var))  ) {
+                 if ( &value_is_true($nl->get_value($var)) ) {
+            	    $var = "flandusepftdat";
+            	    add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, $var,
+            	                'phys'=>$nl_flags->{'phys'}, 'hgrid'=>$nl_flags->{'res'}, nofail=>1 );
+            	    my $fname = remove_leading_and_trailing_quotes( $nl->get_value($var) );
+            	    if ( ! defined($nl->get_value($var))  ) {
+            	      $log->fatal_error("$var is required when use_fates_luh and use_fates_fixed_biogeog is set" );
+            	    } elsif ( ! -f "$fname" ) {
+            	      $log->fatal_error("$var does NOT point to a valid filename" );
+            	    }
+		 }
+	      }
            }
         }
         # check that fates landuse is on and harvest mode is off when potential veg switch is true
         my $var = "use_fates_potentialveg";
         if ( defined($nl->get_value($var))  ) {
-          if ( &value_is_true($nl->get_value($var)) ) {
-            if ( ! &value_is_true($nl->get_value('use_fates_luh')) ) {
-              $log->fatal_error("use_fates_luh must be true when $var is true" );
-            }
-            if ( $nl->get_value('fates_harvest_mode') > 0) {
-              $log->fatal_error("fates_harvest_mode must be off (i.e. set to zero) when $var is true" );
-            }
-          }
+           if ( &value_is_true($nl->get_value($var)) ) {
+              if ( ! &value_is_true($nl->get_value('use_fates_luh')) ) {
+                $log->fatal_error("use_fates_luh must be true when $var is true" );
+              }
+              if ( $nl->get_value('fates_harvest_mode') > 0) {
+                $log->fatal_error("fates_harvest_mode must be off (i.e. set to zero) when $var is true" );
+              }
+              my $var = "fluh_timeseries";
+              if ( defined($nl->get_value($var))  ) {
+                 $log->fatal_error("fluh_timeseries can not be defined when use_fates_potentialveg is true" );
+                 }
+           }
         }
         # Check fates_harvest_mode compatibility
         my $var = "fates_harvest_mode";

--- a/src/dyn_subgrid/dynSubgridDriverMod.F90
+++ b/src/dyn_subgrid/dynSubgridDriverMod.F90
@@ -89,6 +89,11 @@ contains
     ! Note that dynpft_init needs to be called from outside any loops over clumps - so
     ! this routine needs to be called from outside any loops over clumps.
     !
+    !
+    ! !USES:
+    use clm_varctl               , only : fates_harvest_mode
+    use dynFATESLandUseChangeMod , only : fates_harvest_clmlanduse
+    !
     ! !ARGUMENTS:
     type(bounds_type)       , intent(in)    :: bounds_proc ! processor-level bounds
     type(glc_behavior_type) , intent(in)    :: glc_behavior
@@ -123,7 +128,7 @@ contains
     ! flanduse_timeseries file. However, this could theoretically be changed so that the
     ! harvest data were separated from the pftdyn data, allowing them to differ in the
     ! years over which they apply.
-    if (get_do_harvest()) then
+    if (get_do_harvest() .or. fates_harvest_mode >= fates_harvest_clmlanduse) then
        call dynHarvest_init(bounds_proc, harvest_filename=get_flanduse_timeseries())
     end if
 

--- a/src/dyn_subgrid/dynSubgridDriverMod.F90
+++ b/src/dyn_subgrid/dynSubgridDriverMod.F90
@@ -128,7 +128,7 @@ contains
     ! flanduse_timeseries file. However, this could theoretically be changed so that the
     ! harvest data were separated from the pftdyn data, allowing them to differ in the
     ! years over which they apply.
-    if (get_do_harvest() .or. fates_harvest_mode >= fates_harvest_clmlanduse) then
+    if (get_do_harvest() .or. fates_harvest_mode == fates_harvest_clmlanduse) then
        call dynHarvest_init(bounds_proc, harvest_filename=get_flanduse_timeseries())
     end if
 

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -521,7 +521,7 @@ module CLMFatesInterfaceMod
            ! LUH2 landuse timeseries driven  harvest rates
            else if (fates_harvest_mode >= fates_harvest_luh_area) then
               pass_lu_harvest = 1
-              pass_num_lu_harvest_types = num_landuse_harvest_vars
+              pass_num_lu_harvest_cats = num_landuse_harvest_vars
            else
               pass_lu_harvest = 0
               pass_num_lu_harvest_cats = 0

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -526,6 +526,7 @@ module CLMFatesInterfaceMod
               pass_lu_harvest = 0
               pass_num_lu_harvest_cats = 0
            end if
+        end if
 
         ! FATES landuse modes
         if(use_fates_luh) then

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -514,7 +514,7 @@ module CLMFatesInterfaceMod
         if (fates_harvest_mode > fates_harvest_no_logging) then
            pass_logging = 1 ! Time driven logging, without landuse harvest
            ! CLM landuse timeseries driven harvest rates
-           if (fates_harvest_mode == fates_harvest_clmlanduse)
+           if (fates_harvest_mode == fates_harvest_clmlanduse) then
               pass_num_lu_harvest_cats = num_harvest_inst
               pass_lu_harvest = 1
 
@@ -979,7 +979,7 @@ module CLMFatesInterfaceMod
       call GetAndSetTime
 
       ! Get harvest rates for CLM landuse timeseries driven rates
-      if (fates_harvest_mode == fates_harvest_clmlanduse)
+      if (fates_harvest_mode == fates_harvest_clmlanduse) then
          call dynHarvest_interp_resolve_harvesttypes(bounds_clump, &
               harvest_rates=harvest_rates(begg:endg,1:num_harvest_inst), &
               after_start_of_harvest_ts=after_start_of_harvest_ts)
@@ -1105,7 +1105,7 @@ module CLMFatesInterfaceMod
          ! for now there is one veg column per gridcell, so store all harvest data in each site
          ! this will eventually change
          ! today's hlm harvest flag needs to be set no matter what
-         if (fates_harvest_mode == fates_harvest_clmlanduse)
+         if (fates_harvest_mode == fates_harvest_clmlanduse) then
             if (after_start_of_harvest_ts) then
                this%fates(nc)%bc_in(s)%hlm_harvest_rates(1:num_harvest_inst) = harvest_rates(g,1:num_harvest_inst)
             else


### PR DESCRIPTION
### Description of changes
As fates harvest modes have increased we should remove the dependency on `do_harvest` to provide a clearer distinction between CLM and fates harvest mode types.

### Specific notes
The only remaining overlap between the host land model and fates is during the call to `dynHarvestInit`, so we add a check on the fates harvest mode here.

### Testing performed, if any
Build and run test still needed