### PR TITLE
Add namelist options for prescribed crop calendars

### DIFF
--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -4225,11 +4225,14 @@ sub setup_logic_cropcal_streams {
       $log->fatal_error("If providing any crop calendar input file(s), you must provide stream_meshfile_cropcal" );
     }
 
-    # Set first and last stream years
+    # Set stream years
     add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'stream_year_first_cropcal',
                 'sim_year'=>$nl_flags->{'sim_year'},
                 'sim_year_range'=>$nl_flags->{'sim_year_range'});
     add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'stream_year_last_cropcal',
+                'sim_year'=>$nl_flags->{'sim_year'},
+                'sim_year_range'=>$nl_flags->{'sim_year_range'});
+    add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'model_year_align_cropcal',
                 'sim_year'=>$nl_flags->{'sim_year'},
                 'sim_year_range'=>$nl_flags->{'sim_year_range'});
 
@@ -4242,11 +4245,6 @@ sub setup_logic_cropcal_streams {
       if ( !&string_is_undef_or_empty($gdd20_baseline_file) ) {
         $log->fatal_error("If cropcals_rx_adapt is true (i.e., stream_fldFileName_gdd20_baseline is provided), no crop calendar input is allowed to vary over time (i.e., stream_year_first_cropcal and stream_year_last_cropcal must be the same)." );
       }
-
-      # Set align year
-      add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl,
-                  'model_year_align_cropcal', 'sim_year'=>$nl_flags->{'sim_year'},
-                  'sim_year_range'=>$nl_flags->{'sim_year_range'});
     }
   }
 

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -4200,8 +4200,8 @@ sub setup_logic_cropcal_streams {
   my $gdd_file = $nl->get_value('stream_fldFileName_cultivar_gdds') ;
   my $gdd20_baseline_file = $nl->get_value('stream_fldFileName_gdd20_baseline') ;
   my $mesh_file = $nl->get_value('stream_meshfile_cropcal') ;
-  if ( ($swindow_start_file eq '' and $swindow_start_file ne '') or ($swindow_start_file ne '' and $swindow_start_file eq '') ) {
-    $log->fatal_error("When specifying sowing window dates, you must provide both swindow_start_file and swindow_end_file. To specify exact sowing dates, use the same file." );
+  if ( ($swindow_start_file eq '' and $swindow_end_file ne '') or ($swindow_start_file ne '' and $swindow_end_file eq '') ) {
+    $log->fatal_error("When specifying sowing window dates, you must provide both stream_fldFileName_swindow_start and stream_fldFileName_swindow_end. To specify exact sowing dates, use the same file." );
   }
   if ( $gdd_file eq '' and $gdd20_baseline_file ne '' ) {
       $log->fatal_error("If not providing stream_fldFileName_cultivar_gdds, don't provide stream_fldFileName_gdd20_baseline");

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -4200,30 +4200,30 @@ sub setup_logic_cropcal_streams {
   my $gdd_file = $nl->get_value('stream_fldFileName_cultivar_gdds') ;
   my $gdd20_baseline_file = $nl->get_value('stream_fldFileName_gdd20_baseline') ;
   my $mesh_file = $nl->get_value('stream_meshfile_cropcal') ;
-  if ( ($swindow_start_file eq '' and $swindow_end_file ne '') or ($swindow_start_file ne '' and $swindow_end_file eq '') ) {
+  if ( (&string_is_undef_or_empty($swindow_start_file) and !&string_is_undef_or_empty($swindow_end_file)) or (!&string_is_undef_or_empty($swindow_start_file) and &string_is_undef_or_empty($swindow_end_file)) ) {
     $log->fatal_error("When specifying sowing window dates, you must provide both stream_fldFileName_swindow_start and stream_fldFileName_swindow_end. To specify exact sowing dates, use the same file." );
   }
-  if ( $gdd_file eq '' and $gdd20_baseline_file ne '' ) {
+  if ( &string_is_undef_or_empty($gdd_file) and ! &string_is_undef_or_empty($gdd20_baseline_file) ) {
       $log->fatal_error("If not providing stream_fldFileName_cultivar_gdds, don't provide stream_fldFileName_gdd20_baseline");
   }
   if ( $generate_crop_gdds eq '.true.' ) {
       if ( $use_mxmat eq '.true.' ) {
           $log->fatal_error("If generate_crop_gdds is true, you must also set use_mxmat to false" );
       }
-      if ( $swindow_start_file eq '' or $swindow_end_file eq '' ) {
+      if ( &string_is_undef_or_empty($swindow_start_file) or &string_is_undef_or_empty($swindow_end_file) ) {
           $log->fatal_error("If generate_crop_gdds is true, you must specify stream_fldFileName_swindow_start and stream_fldFileName_swindow_end")
       }
       if ( $swindow_start_file ne $swindow_end_file ) {
           $log->fatal_error("If generate_crop_gdds is true, you must specify exact sowing dates by setting stream_fldFileName_swindow_start and stream_fldFileName_swindow_end to the same file")
       }
-      if ( $gdd_file ne '' ) {
+      if ( ! &string_is_undef_or_empty($gdd_file) ) {
           $log->fatal_error("If generate_crop_gdds is true, do not specify stream_fldFileName_cultivar_gdds")
       }
-      if ( $gdd20_baseline_file ne '' ) {
+      if ( ! &string_is_undef_or_empty($gdd20_baseline_file) ) {
           $log->fatal_error("If generate_crop_gdds is true, do not specify stream_fldFileName_gdd20_baseline")
       }
   }
-  if ( $mesh_file eq '' and ( $swindow_start_file ne '' or $gdd_file ne '' ) ) {
+  if ( &string_is_undef_or_empty($mesh_file) and ( ! &string_is_undef_or_empty($swindow_start_file) or ! &string_is_undef_or_empty($gdd_file) ) ) {
       $log->fatal_error("If prescribing crop sowing dates and/or maturity requirements, you must specify stream_meshfile_cropcal")
   }
 }

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -4206,8 +4206,8 @@ sub setup_logic_cropcal_streams {
   if ( &string_is_undef_or_empty($gdd_file) and ! &string_is_undef_or_empty($gdd20_baseline_file) ) {
       $log->fatal_error("If not providing stream_fldFileName_cultivar_gdds, don't provide stream_fldFileName_gdd20_baseline");
   }
-  if ( $generate_crop_gdds eq '.true.' ) {
-      if ( $use_mxmat eq '.true.' ) {
+  if ( &value_is_true($generate_crop_gdds) ) {
+      if ( &value_is_true($use_mxmat) ) {
           $log->fatal_error("If generate_crop_gdds is true, you must also set use_mxmat to false" );
       }
       if ( &string_is_undef_or_empty($swindow_start_file) or &string_is_undef_or_empty($swindow_end_file) ) {

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -1686,10 +1686,17 @@ lnd/clm2/surfdata_esmf/NEON/surfdata_1x1_NEON_TOOL_hist_78pfts_CMIP6_simyr2000_c
 <lai_mapalgo  hgrid="1x1_asphaltjungleNJ" >nn</lai_mapalgo>
 <lai_mapalgo  hgrid="5x5_amazon"          >nn</lai_mapalgo>
 
-<!-- crop calendar streams namelist defaults -->
-<stream_year_first_cropcal  >1850</stream_year_first_cropcal>
-<stream_year_last_cropcal   >2100</stream_year_last_cropcal>
-<model_year_align_cropcal   >1850</model_year_align_cropcal>
+<!-- crop calendars: default settings -->
+<cropcals_rx>.false.</cropcals_rx>
+<stream_year_first_cropcal  >2000</stream_year_first_cropcal>
+<stream_year_last_cropcal   >2000</stream_year_last_cropcal>
+<model_year_align_cropcal   >2000</model_year_align_cropcal>
+
+<!-- crop calendars: default input files -->
+<stream_fldFileName_swindow_start cropcals_rx=".true.">lnd/clm2/cropdata/calendars/processed/swindow_starts_ggcmi_crop_calendar_phase3_v1.01.2000-2000.20231005_145103.nc</stream_fldFileName_swindow_start>
+<stream_fldFileName_swindow_end cropcals_rx=".true.">lnd/clm2/cropdata/calendars/processed/swindow_ends_ggcmi_crop_calendar_phase3_v1.01.2000-2000.20231005_145103.nc</stream_fldFileName_swindow_end>
+<stream_fldfilename_cultivar_gdds cropcals_rx=".true.">lnd/clm2/cropdata/calendars/processed/gdds_20230829_161011.nc</stream_fldfilename_cultivar_gdds>
+<stream_meshfile_cropcal cropcals_rx=".true.">share/meshes/360x720_120830_ESMFmesh_c20210507_cdf5.nc</stream_meshfile_cropcal>
 
 <!-- lightning streams namelist defaults -->
 

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -1688,6 +1688,7 @@ lnd/clm2/surfdata_esmf/NEON/surfdata_1x1_NEON_TOOL_hist_78pfts_CMIP6_simyr2000_c
 
 <!-- crop calendars: default settings -->
 <cropcals_rx>.false.</cropcals_rx>
+<cropcals_rx_adapt>.false.</cropcals_rx_adapt>
 <stream_year_first_cropcal  >2000</stream_year_first_cropcal>
 <stream_year_last_cropcal   >2000</stream_year_last_cropcal>
 <model_year_align_cropcal   >2000</model_year_align_cropcal>
@@ -1697,6 +1698,11 @@ lnd/clm2/surfdata_esmf/NEON/surfdata_1x1_NEON_TOOL_hist_78pfts_CMIP6_simyr2000_c
 <stream_fldFileName_swindow_end cropcals_rx=".true.">lnd/clm2/cropdata/calendars/processed/swindow_ends_ggcmi_crop_calendar_phase3_v1.01.2000-2000.20231005_145103.nc</stream_fldFileName_swindow_end>
 <stream_fldfilename_cultivar_gdds cropcals_rx=".true.">lnd/clm2/cropdata/calendars/processed/gdds_20230829_161011.nc</stream_fldfilename_cultivar_gdds>
 <stream_meshfile_cropcal cropcals_rx=".true.">share/meshes/360x720_120830_ESMFmesh_c20210507_cdf5.nc</stream_meshfile_cropcal>
+<stream_fldFileName_swindow_start cropcals_rx_adapt=".true.">lnd/clm2/cropdata/calendars/processed/swindow_starts_ggcmi_crop_calendar_phase3_v1.01.2000-2000.20231005_145103.nc</stream_fldFileName_swindow_start>
+<stream_fldFileName_swindow_end cropcals_rx_adapt=".true.">lnd/clm2/cropdata/calendars/processed/swindow_ends_ggcmi_crop_calendar_phase3_v1.01.2000-2000.20231005_145103.nc</stream_fldFileName_swindow_end>
+<stream_fldfilename_cultivar_gdds cropcals_rx_adapt=".true.">lnd/clm2/cropdata/calendars/processed/gdds_20230829_161011.nc</stream_fldfilename_cultivar_gdds>
+<stream_fldFileName_gdd20_baseline cropcals_rx_adapt=".true.">lnd/clm2/testdata/gdd20baseline.tmp_dontupload.nc</stream_fldFileName_gdd20_baseline>
+<stream_meshfile_cropcal cropcals_rx_adapt=".true.">share/meshes/360x720_120830_ESMFmesh_c20210507_cdf5.nc</stream_meshfile_cropcal>
 
 <!-- lightning streams namelist defaults -->
 

--- a/bld/namelist_files/namelist_definition_ctsm.xml
+++ b/bld/namelist_files/namelist_definition_ctsm.xml
@@ -1773,14 +1773,19 @@ Mapping method from LAI input file to the model resolution
 <!-- ========================================================================================  -->
 
 <!-- Crop calendars -->
+<entry id="cropcals_rx" type="logical" category="datasets"
+       group="cropcal_streams" valid_values="" >
+Flag to enable prescribed crop calendars (sowing window dates and maturity requirement)
+</entry>
+
 <entry id="stream_year_first_cropcal" type="integer" category="datasets"
        group="cropcal_streams" valid_values="" >
-First year to loop over for crop calendar data
+First year to loop over for crop calendar data (not including gdd20_baseline file)
 </entry>
 
 <entry id="stream_year_last_cropcal" type="integer" category="datasets"
        group="cropcal_streams" valid_values="" >
-Last year to loop over for crop calendar data
+Last year to loop over for crop calendar data (not including gdd20_baseline file)
 </entry>
 
 <entry id="model_year_align_cropcal" type="integer" category="datasets"

--- a/bld/namelist_files/namelist_definition_ctsm.xml
+++ b/bld/namelist_files/namelist_definition_ctsm.xml
@@ -1778,6 +1778,11 @@ Mapping method from LAI input file to the model resolution
 Flag to enable prescribed crop calendars (sowing window dates and maturity requirement)
 </entry>
 
+<entry id="cropcals_rx_adapt" type="logical" category="datasets"
+       group="cropcal_streams" valid_values="" >
+Flag to enable prescribed crop calendars (sowing window dates and maturity requirement), with maturity requirement adaptive based on recent climate
+</entry>
+
 <entry id="stream_year_first_cropcal" type="integer" category="datasets"
        group="cropcal_streams" valid_values="" >
 First year to loop over for crop calendar data (not including gdd20_baseline file)

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -3719,5 +3719,23 @@
     </options>
   </test>
 
+  <test name="SMS_P128x1_Lm25" grid="f10_f10_mg37" compset="IHistClm60BgcCrop" testmods="clm/RxCropCals">
+    <machines>
+      <machine name="derecho" compiler="intel" category="crop_calendars"/>
+    </machines>
+    <options>
+      <option name="wallclock">01:00:00</option>
+    </options>
+  </test>
+
+  <test name="ERS_P128x1_Lm25" grid="f10_f10_mg37" compset="IHistClm60BgcCrop" testmods="clm/RxCropCalsAdapt">
+    <machines>
+      <machine name="derecho" compiler="intel" category="crop_calendars"/>
+    </machines>
+    <options>
+      <option name="wallclock">01:00:00</option>
+    </options>
+  </test>
+
 
 </testlist>

--- a/cime_config/testdefs/testmods_dirs/clm/RxCropCals/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/RxCropCals/user_nl_clm
@@ -1,8 +1,2 @@
 
-! Sowing windows
-stream_fldFileName_swindow_start = '$DIN_LOC_ROOT/lnd/clm2/cropdata/calendars/processed/swindow_starts_ggcmi_crop_calendar_phase3_v1.01.2000-2000.20231005_145103.nc'
-stream_fldFileName_swindow_end  = '$DIN_LOC_ROOT/lnd/clm2/cropdata/calendars/processed/swindow_ends_ggcmi_crop_calendar_phase3_v1.01.2000-2000.20231005_145103.nc'
-stream_fldFileName_cultivar_gdds = '$DIN_LOC_ROOT/lnd/clm2/cropdata/calendars/processed/gdds_20230829_161011.nc'
-stream_year_first_cropcal = 2000
-stream_year_last_cropcal = 2000
-stream_meshfile_cropcal = '$DIN_LOC_ROOT/share/meshes/360x720_120830_ESMFmesh_c20210507_cdf5.nc'
+cropcals_rx = .true.

--- a/cime_config/testdefs/testmods_dirs/clm/RxCropCalsAdapt/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/RxCropCalsAdapt/user_nl_clm
@@ -1,3 +1,3 @@
 
-! Eventually replace this with half-degree version in the proper place
-stream_fldFileName_gdd20_baseline = '/glade/u/home/samrabin/ctsm_scale-mat-reqs/tools/crop_calendars/test.nc'
+cropcals_rx = .false.
+cropcals_rx_adapt = .true.

--- a/src/cpl/share_esmf/cropcalStreamMod.F90
+++ b/src/cpl/share_esmf/cropcalStreamMod.F90
@@ -47,6 +47,7 @@ module cropcalStreamMod
   character(len=CL)       :: stream_fldFileName_swindow_end   ! sowing window end stream filename to read
   character(len=CL)       :: stream_fldFileName_cultivar_gdds ! cultivar growing degree-days stream filename to read
   character(len=CL)       :: stream_fldFileName_gdd20_baseline ! GDD20 baseline stream filename to read
+  logical                 :: cropcals_rx ! Used only for setting input files in namelist; does nothing in code, but needs to be here so namelist read doesn't crash
 
   character(len=*), parameter :: sourcefile = &
        __FILE__
@@ -95,7 +96,8 @@ contains
          stream_fldFileName_swindow_end,   &
          stream_fldFileName_cultivar_gdds, &
          stream_fldFileName_gdd20_baseline, &
-         stream_meshfile_cropcal
+         stream_meshfile_cropcal, &
+         cropcals_rx
 
     ! Default values for namelist
     stream_year_first_cropcal  = 1      ! first year in stream to use

--- a/src/cpl/share_esmf/cropcalStreamMod.F90
+++ b/src/cpl/share_esmf/cropcalStreamMod.F90
@@ -48,6 +48,7 @@ module cropcalStreamMod
   character(len=CL)       :: stream_fldFileName_cultivar_gdds ! cultivar growing degree-days stream filename to read
   character(len=CL)       :: stream_fldFileName_gdd20_baseline ! GDD20 baseline stream filename to read
   logical                 :: cropcals_rx ! Used only for setting input files in namelist; does nothing in code, but needs to be here so namelist read doesn't crash
+  logical                 :: cropcals_rx_adapt ! Used only for setting input files in namelist; does nothing in code, but needs to be here so namelist read doesn't crash
 
   character(len=*), parameter :: sourcefile = &
        __FILE__
@@ -97,7 +98,8 @@ contains
          stream_fldFileName_cultivar_gdds, &
          stream_fldFileName_gdd20_baseline, &
          stream_meshfile_cropcal, &
-         cropcals_rx
+         cropcals_rx, &
+         cropcals_rx_adapt
 
     ! Default values for namelist
     stream_year_first_cropcal  = 1      ! first year in stream to use


### PR DESCRIPTION
### Description of changes

Building on top of #2560, this PR adds namelist options `cropcals_rx` (run with prescribed sowing windows and static maturity requirements) and `cropcals_rx_adapt` (as `cropcals_rx` but with maturity requirements allowed to shift with climate). The `cropcals_rx_adapt` setup is purely proof-of-concept at this point, as the new input file it relies on is not one we'll be using moving forward. But at this point in development I didn't want to spend the time making a proper one, because it would soon be superseded.

This is the second PR in this effort:
1. (#2560) Define "recent climate" based on the same "warm period" currently used by default CLM.
1.1. (This PR) Add more namelist options and checks.
2. Define "recent climate" based on the GGCMI growing seasons.
3. Restrict adapted `gddmaturity` values to a realistic range.

### Specific notes

**Contributors other than yourself, if any:** None

**CTSM Issues Fixed (include github issue #):**
- Contributes to #1928

**Are answers expected to change (and if so in what way)?** No

**Any User Interface Changes (namelist or namelist defaults changes)?**
- Adds boolean namelist parameter `cropcals_rx`
- Adds boolean namelist parameter `cropcals_rx_adapt`

**Does this create a need to change or add documentation? Did you do so?** No, not yet.

**Testing performed, if any:**
- [x] Various checks of allowed and disallowed namelist option combinations
- [x] Runs using the new options are bit-for-bit identical with runs using a manual setup before introducing those options
- [ ] aux_clm
