### PR TITLE
Simplify tower types

### DIFF
--- a/python/ctsm/site_and_regional/neon_site.py
+++ b/python/ctsm/site_and_regional/neon_site.py
@@ -34,6 +34,9 @@ class NeonSite(TowerSite):
     A class for encapsulating neon sites.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__("NEON", *args, **kwargs)
+
     def modify_user_nl(self, case_root, run_type, rundir, site_lines=None):
         # TODO: include neon-specific user namelist lines, using this as just an example currently
         if site_lines is None:

--- a/python/ctsm/site_and_regional/neon_site.py
+++ b/python/ctsm/site_and_regional/neon_site.py
@@ -34,34 +34,6 @@ class NeonSite(TowerSite):
     A class for encapsulating neon sites.
     """
 
-    def build_base_case(
-        self,
-        cesmroot,
-        output_root,
-        res,
-        compset,
-        user_mods_dirs=None,
-        overwrite=False,
-        setup_only=False,
-    ):
-        if user_mods_dirs is None:
-            user_mods_dirs = [
-                os.path.join(
-                    self.cesmroot, "cime_config", "usermods_dirs", "clm", "NEON", self.name
-                )
-            ]
-        case_path = super().build_base_case(
-            cesmroot,
-            output_root,
-            res,
-            compset,
-            user_mods_dirs,
-            overwrite=overwrite,
-            setup_only=setup_only,
-        )
-
-        return case_path
-
     # pylint: disable=too-many-statements
     def run_case(
         self,
@@ -69,7 +41,6 @@ class NeonSite(TowerSite):
         run_type,
         prism,
         user_version,
-        tower_type=None,
         user_mods_dirs=None,
         overwrite=False,
         setup_only=False,
@@ -106,16 +77,16 @@ class NeonSite(TowerSite):
             default False
         """
         user_mods_dirs = [
-            os.path.join(self.cesmroot, "cime_config", "usermods_dirs", "clm", "NEON", self.name)
+            os.path.join(
+                self.cesmroot, "cime_config", "usermods_dirs", "clm", self.tower_type, self.name
+            )
         ]
-        tower_type = "NEON"
 
         super().run_case(
             base_case_root,
             run_type,
             prism,
             user_version,
-            tower_type,
             user_mods_dirs,
             overwrite,
             setup_only,

--- a/python/ctsm/site_and_regional/neon_site.py
+++ b/python/ctsm/site_and_regional/neon_site.py
@@ -34,69 +34,6 @@ class NeonSite(TowerSite):
     A class for encapsulating neon sites.
     """
 
-    # pylint: disable=too-many-statements
-    def run_case(
-        self,
-        base_case_root,
-        run_type,
-        prism,
-        user_version,
-        user_mods_dirs=None,
-        overwrite=False,
-        setup_only=False,
-        no_batch=False,
-        rerun=False,
-        experiment=False,
-        no_input_data_check=False,
-        xmlchange=None,
-    ):
-        """
-        Run case.
-
-        Args:
-        self
-        base_case_root: str, opt
-            file path of base case
-        run_type: str, opt
-            transient, post_ad, or ad case, default transient
-        prism: bool, opt
-            if True, use PRISM precipitation, default False
-        user_version: str, opt
-            default 'latest'
-        overwrite: bool, opt
-            default False
-        setup_only: bool, opt
-            default False; if True, set up but do not run case
-        no_batch: bool, opt
-            default False
-        rerun: bool, opt
-            default False
-        experiment: str, opt
-            name of experiment, default False
-        no_input_data_check: bool, opt
-            default False
-        """
-        user_mods_dirs = [
-            os.path.join(
-                self.cesmroot, "cime_config", "usermods_dirs", "clm", self.tower_type, self.name
-            )
-        ]
-
-        super().run_case(
-            base_case_root,
-            run_type,
-            prism,
-            user_version,
-            user_mods_dirs,
-            overwrite,
-            setup_only,
-            no_batch,
-            rerun,
-            experiment,
-            no_input_data_check,
-            xmlchange,
-        )
-
     def modify_user_nl(self, case_root, run_type, rundir, site_lines=None):
         # TODO: include neon-specific user namelist lines, using this as just an example currently
         if site_lines is None:

--- a/python/ctsm/site_and_regional/plumber_site.py
+++ b/python/ctsm/site_and_regional/plumber_site.py
@@ -33,69 +33,6 @@ class Plumber2Site(TowerSite):
     A class for encapsulating plumber sites.
     """
 
-    # pylint: disable=too-many-statements
-    def run_case(
-        self,
-        base_case_root,
-        run_type,
-        prism,
-        user_version,
-        user_mods_dirs=None,
-        overwrite=False,
-        setup_only=False,
-        no_batch=False,
-        rerun=False,
-        experiment=False,
-        no_input_data_check=False,
-        xmlchange=None,
-    ):
-        """
-        Run case.
-
-        Args:
-        self
-        base_case_root: str, opt
-            file path of base case
-        run_type: str, opt
-            transient, post_ad, or ad case, default ad
-            (ad case is default because PLUMBER requires spinup)
-        prism: bool, opt
-            if True, use PRISM precipitation, default False
-            Note: only supported for NEON sites
-        user_version: str, opt
-            default 'latest'; this could be useful later
-            This is currently only implemented with neon (not plumber) sites
-        overwrite: bool, opt
-            default False
-        setup_only: bool, opt
-            default False; if True, set up but do not run case
-        no_batch: bool, opt
-            default False
-        rerun: bool, opt
-            default False
-        experiment: str, opt
-            name of experiment, default False
-        """
-        user_mods_dirs = [
-            os.path.join(
-                self.cesmroot, "cime_config", "usermods_dirs", "clm", self.tower_type, self.name
-            )
-        ]
-        super().run_case(
-            base_case_root,
-            run_type,
-            prism,
-            user_version,
-            user_mods_dirs,
-            overwrite,
-            setup_only,
-            no_batch,
-            rerun,
-            experiment,
-            no_input_data_check,
-            xmlchange,
-        )
-
     def set_ref_case(self, case):
         super().set_ref_case(case)
         return True  ### Check if super returns false, if this will still return True?

--- a/python/ctsm/site_and_regional/plumber_site.py
+++ b/python/ctsm/site_and_regional/plumber_site.py
@@ -33,6 +33,9 @@ class Plumber2Site(TowerSite):
     A class for encapsulating plumber sites.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__("PLUMBER2", *args, **kwargs)
+
     def set_ref_case(self, case):
         super().set_ref_case(case)
         return True  ### Check if super returns false, if this will still return True?

--- a/python/ctsm/site_and_regional/plumber_site.py
+++ b/python/ctsm/site_and_regional/plumber_site.py
@@ -33,34 +33,6 @@ class Plumber2Site(TowerSite):
     A class for encapsulating plumber sites.
     """
 
-    def build_base_case(
-        self,
-        cesmroot,
-        output_root,
-        res,
-        compset,
-        user_mods_dirs=None,
-        overwrite=False,
-        setup_only=False,
-    ):
-        if user_mods_dirs is None:
-            user_mods_dirs = [
-                os.path.join(
-                    self.cesmroot, "cime_config", "usermods_dirs", "clm", "PLUMBER2", self.name
-                )
-            ]
-        case_path = super().build_base_case(
-            cesmroot,
-            output_root,
-            res,
-            compset,
-            user_mods_dirs,
-            overwrite=overwrite,
-            setup_only=setup_only,
-        )
-
-        return case_path
-
     # pylint: disable=too-many-statements
     def run_case(
         self,
@@ -68,7 +40,6 @@ class Plumber2Site(TowerSite):
         run_type,
         prism,
         user_version,
-        tower_type=None,
         user_mods_dirs=None,
         overwrite=False,
         setup_only=False,
@@ -107,16 +78,14 @@ class Plumber2Site(TowerSite):
         """
         user_mods_dirs = [
             os.path.join(
-                self.cesmroot, "cime_config", "usermods_dirs", "clm", "PLUMBER2", self.name
+                self.cesmroot, "cime_config", "usermods_dirs", "clm", self.tower_type, self.name
             )
         ]
-        tower_type = "PLUMBER"
         super().run_case(
             base_case_root,
             run_type,
             prism,
             user_version,
-            tower_type,
             user_mods_dirs,
             overwrite,
             setup_only,

--- a/python/ctsm/site_and_regional/run_tower.py
+++ b/python/ctsm/site_and_regional/run_tower.py
@@ -265,9 +265,9 @@ def main(description):
                 if run_from_postad:
                     neon_site.finidat = None
                 if not base_case_root:
-                    user_mods_dirs = None
+                    neon_site.set_default_user_mods_dirs()
                     base_case_root = neon_site.build_base_case(
-                        cesmroot, output_root, res, compset, user_mods_dirs, overwrite, setup_only
+                        cesmroot, output_root, res, compset, overwrite, setup_only
                     )
                 logger.info("-----------------------------------")
                 logger.info("Running CTSM for neon site : %s", neon_site.name)
@@ -296,9 +296,9 @@ def main(description):
                 if run_from_postad:
                     plumber_site.finidat = None
                 if not base_case_root:
-                    user_mods_dirs = None
+                    plumber_site.set_default_user_mods_dirs()
                     base_case_root = plumber_site.build_base_case(
-                        cesmroot, output_root, res, compset, user_mods_dirs, overwrite, setup_only
+                        cesmroot, output_root, res, compset, overwrite, setup_only
                     )
                 logger.info("-----------------------------------")
                 logger.info("Running CTSM for plumber site : %s", plumber_site.name)

--- a/python/ctsm/site_and_regional/run_tower.py
+++ b/python/ctsm/site_and_regional/run_tower.py
@@ -160,7 +160,9 @@ def parse_neon_listing(listing_file, valid_neon_sites):
                 if site_name in line:
                     finidat = line.split(",")[0].split("/")[-1]
 
-            neon_site = NeonSite(site_name, start_year, end_year, start_month, end_month, finidat)
+            neon_site = NeonSite(
+                "NEON", site_name, start_year, end_year, start_month, end_month, finidat
+            )
             logger.debug(neon_site)
             available_list.append(neon_site)
 
@@ -192,7 +194,7 @@ def setup_plumber_data(valid_plumber_sites):
         finidat = None
 
         plumber_site = Plumber2Site(
-            site_name, start_year, end_year, start_month, end_month, finidat
+            "PLUMBER2", site_name, start_year, end_year, start_month, end_month, finidat
         )
         available_list.append(plumber_site)
 

--- a/python/ctsm/site_and_regional/run_tower.py
+++ b/python/ctsm/site_and_regional/run_tower.py
@@ -160,9 +160,7 @@ def parse_neon_listing(listing_file, valid_neon_sites):
                 if site_name in line:
                     finidat = line.split(",")[0].split("/")[-1]
 
-            neon_site = NeonSite(
-                "NEON", site_name, start_year, end_year, start_month, end_month, finidat
-            )
+            neon_site = NeonSite(site_name, start_year, end_year, start_month, end_month, finidat)
             logger.debug(neon_site)
             available_list.append(neon_site)
 
@@ -194,7 +192,7 @@ def setup_plumber_data(valid_plumber_sites):
         finidat = None
 
         plumber_site = Plumber2Site(
-            "PLUMBER2", site_name, start_year, end_year, start_month, end_month, finidat
+            site_name, start_year, end_year, start_month, end_month, finidat
         )
         available_list.append(plumber_site)
 

--- a/python/ctsm/test/test_sys_run_tower.py
+++ b/python/ctsm/test/test_sys_run_tower.py
@@ -120,9 +120,9 @@ class TestSysRunTower(unittest.TestCase):
         # assert that AR-SLu directories were created during setup
         self.assertTrue("AR-SLu" in glob.glob(self._tempdir + "/AR-SLu*")[0])
 
-    def test_xmlchange_neon(self):
+    def test_xmlchange(self):
         """
-        This test checks that the --xmlchange argument is obeyed for a NEON site.
+        This test checks that the --xmlchange argument is obeyed.
         """
 
         # run the run_tower tool
@@ -152,40 +152,9 @@ class TestSysRunTower(unittest.TestCase):
             print(f"CCSM_CO2_PPMV = {value}")
             self.assertTrue(int(value) == 1987)
 
-    def test_xmlchange_plumber(self):
+    def test_setup_only(self):
         """
-        This test checks that the --xmlchange argument is obeyed for a PLUMBER site.
-        """
-
-        # run the run_tower tool for plumber site
-        sys.argv = [
-            os.path.join(path_to_ctsm_root(), "tools", "site_and_regional", "run_tower"),
-            "--plumber-sites",
-            "AR-SLu",
-            "--no-input-data-check",
-            "--experiment",
-            "TEST",
-            "--xmlchange",
-            "CLM_CO2_TYPE=constant,CCSM_CO2_PPMV=1987",
-            "--output-root",
-            self._tempdir,
-        ]
-        main("")
-
-        # Check that the --xmlchange argument is obeyed
-        case_dir = os.path.join(self._tempdir, "AR-SLu.TEST.ad")
-        self.assertTrue(os.path.exists(case_dir))
-        with Case(case_dir, read_only=True) as case:
-            value = case.get_value("CLM_CO2_TYPE")
-            print(f"CLM_CO2_TYPE = {value}")
-            self.assertTrue(value == "constant")
-            value = int(case.get_value("CCSM_CO2_PPMV"))
-            print(f"CCSM_CO2_PPMV = {value}")
-            self.assertTrue(int(value) == 1987)
-
-    def test_setup_only_neon(self):
-        """
-        This test checks that the --setup-only argument is obeyed for NEON sites
+        This test checks that the --setup-only argument is obeyed
         """
 
         # run the run_tower tool
@@ -209,34 +178,9 @@ class TestSysRunTower(unittest.TestCase):
         self.assertTrue(os.path.exists(build_dir_to_check))
         self.assertTrue(len(os.listdir(build_dir_to_check)) == 0)
 
-    def test_setup_only_plumber(self):
+    def test_overwrite(self):
         """
-        This test checks that the --setup-only argument is obeyed for PLUMBER sites
-        """
-
-        # run the run_tower tool for plumber site
-        site_name = "AR-SLu"
-        sys.argv = [
-            os.path.join(path_to_ctsm_root(), "tools", "site_and_regional", "run_tower"),
-            "--plumber-sites",
-            site_name,
-            "--setup-only",
-            "--experiment",
-            "TEST",
-            "--output-root",
-            self._tempdir,
-        ]
-        main("")
-
-        # make sure that build didn't happen: this dir should be empty
-        case_dir = os.path.join(self._tempdir, site_name)
-        build_dir_to_check = os.path.join(case_dir, "bld", "cpl", "obj")
-        self.assertTrue(os.path.exists(build_dir_to_check))
-        self.assertTrue(len(os.listdir(build_dir_to_check)) == 0)
-
-    def test_overwrite_neon(self):
-        """
-        This test checks that the --overwrite argument is obeyed for NEON sites
+        This test checks that the --overwrite argument is obeyed
         """
 
         # run the run_tower tool once
@@ -252,39 +196,6 @@ class TestSysRunTower(unittest.TestCase):
             self._tempdir,
         ]
         print(sys.argv)
-        main("")
-
-        # create a file that should be erased during the upcoming overwrite
-        case_dir = os.path.join(self._tempdir, site_name)
-        test_file = os.path.join(case_dir, "test_file")
-        pathlib.Path(test_file).touch()
-        self.assertTrue(os.path.exists(test_file))
-
-        # run the tool again, overwriting existing
-        sys.argv += ["--overwrite"]
-        print(sys.argv)
-        main("")
-
-        # ensure that file we created is gone
-        self.assertFalse(os.path.exists(test_file))
-
-    def test_overwrite_plumber(self):
-        """
-        This test checks that the --overwrite argument is obeyed for PLUMBER sites
-        """
-
-        # run the run_tower tool once
-        site_name = "AR-SLu"
-        sys.argv = [
-            os.path.join(path_to_ctsm_root(), "tools", "site_and_regional", "run_tower"),
-            "--plumber-sites",
-            site_name,
-            "--no-input-data-check",
-            "--experiment",
-            "TEST",
-            "--output-root",
-            self._tempdir,
-        ]
         main("")
 
         # create a file that should be erased during the upcoming overwrite

--- a/python/ctsm/test/test_unit_neon_site.py
+++ b/python/ctsm/test/test_unit_neon_site.py
@@ -62,9 +62,9 @@ class TestNeonSite(unittest.TestCase):
         rundir = ""
 
         # create NeonSite object and update namelist
-        NeonSite(
-            "NEON", name, start_year, end_year, start_month, end_month, finidat
-        ).modify_user_nl(case_root, run_type, rundir)
+        NeonSite(name, start_year, end_year, start_month, end_month, finidat).modify_user_nl(
+            case_root, run_type, rundir
+        )
 
         # gather file contents for test
         new_nl_file = open(glob.glob(case_root + "/*")[0], "r")
@@ -97,9 +97,9 @@ class TestNeonSite(unittest.TestCase):
         rundir = ""
 
         # create NeonSite object and update namelist
-        NeonSite(
-            "NEON", name, start_year, end_year, start_month, end_month, finidat
-        ).modify_user_nl(case_root, run_type, rundir)
+        NeonSite(name, start_year, end_year, start_month, end_month, finidat).modify_user_nl(
+            case_root, run_type, rundir
+        )
 
         # gather file contents for test
         new_nl_file = open(glob.glob(case_root + "/*")[0], "r")

--- a/python/ctsm/test/test_unit_neon_site.py
+++ b/python/ctsm/test/test_unit_neon_site.py
@@ -62,9 +62,9 @@ class TestNeonSite(unittest.TestCase):
         rundir = ""
 
         # create NeonSite object and update namelist
-        NeonSite(name, start_year, end_year, start_month, end_month, finidat).modify_user_nl(
-            case_root, run_type, rundir
-        )
+        NeonSite(
+            "NEON", name, start_year, end_year, start_month, end_month, finidat
+        ).modify_user_nl(case_root, run_type, rundir)
 
         # gather file contents for test
         new_nl_file = open(glob.glob(case_root + "/*")[0], "r")
@@ -97,9 +97,9 @@ class TestNeonSite(unittest.TestCase):
         rundir = ""
 
         # create NeonSite object and update namelist
-        NeonSite(name, start_year, end_year, start_month, end_month, finidat).modify_user_nl(
-            case_root, run_type, rundir
-        )
+        NeonSite(
+            "NEON", name, start_year, end_year, start_month, end_month, finidat
+        ).modify_user_nl(case_root, run_type, rundir)
 
         # gather file contents for test
         new_nl_file = open(glob.glob(case_root + "/*")[0], "r")

--- a/python/ctsm/test/test_unit_tower_site.py
+++ b/python/ctsm/test/test_unit_tower_site.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Unit tests for tower_site that aren't specific to a single tower type
+
+You can run this by:
+    python -m unittest test_unit_tower_site.py
+"""
+
+import unittest
+import tempfile
+import shutil
+import os
+import sys
+
+# -- add python/ctsm  to path (needed if we want to run the test stand-alone)
+_CTSM_PYTHON = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir, os.pardir)
+sys.path.insert(1, _CTSM_PYTHON)
+
+# pylint: disable=wrong-import-position
+from ctsm import unit_testing
+from ctsm.site_and_regional.tower_site import TowerSite, ALLOWED_SITE_TYPES
+
+# pylint: disable=invalid-name
+
+
+class Test_tower_site(unittest.TestCase):
+    """
+    Basic class for testing tower_site.py for things not specific to any tower type.
+    """
+
+    def setUp(self):
+        """
+        Make /_tempdir for use by these tests.
+        """
+        self._previous_dir = os.getcwd()
+        self._tempdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        """
+        Remove temporary directory
+        """
+        os.chdir(self._previous_dir)
+        shutil.rmtree(self._tempdir, ignore_errors=True)
+
+    def test_disallowed_tower_types(self):
+        """
+        Test that an invalid tower type throws an error
+        """
+        # NeonSite parameters (not that it matters)
+        name = "ABBY"
+        start_year = 2020
+        end_year = 2021
+        start_month = 1
+        end_month = 12
+        # finidat = None
+        finidat = "dummy_finidat"
+
+        # try to create site
+        invalid_type = "INVALIDTYPE"
+        err_msg = (
+            f"tower_type '{invalid_type}' not allowed. "
+            + f"Choose from: {','.join(ALLOWED_SITE_TYPES)}"
+        )
+        with self.assertRaisesRegex(ValueError, err_msg):
+            TowerSite(invalid_type, name, start_year, end_year, start_month, end_month, finidat)
+
+
+if __name__ == "__main__":
+    unit_testing.setup_for_tests()
+    unittest.main()


### PR DESCRIPTION
### Description of changes

Simplifies child types of `TowerSite` (`NeonSite`, `Plumber2Site`).

### Specific notes

**Contributors other than yourself, if any:** None

**CTSM Issues Fixed:** None

**Are answers expected to change (and if so in what way)?** No

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Does this create a need to change or add documentation? Did you do so?** No

**Testing performed, if any:**
- All Python unit testing
- `test_sys_run_tower.py`